### PR TITLE
Variable URLs for WFCatalog and FDSNWS services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,15 @@ RUN ln -s /usr/share/fonts/bootswatch/ fonts
 
 EXPOSE 3000 
 
-CMD ["npm", "start"]
+# Set default external URLs
+ENV WFCATALOG_ADDRESS "http://ws.resif.fr/eidaws/wfcatalog/1/query"
+ENV FDSNWS_ADDRESS "http://ws.resif.fr/fdsnws/station/1/query"
+
+# Dynamically rewrite external URLs based on environment variables
+# Note that double quotes in sed expression must be escaped e.g. \"
+CMD \
+  sed -i -E "s|(var WFCATALOG_ADDRESS =).*|\1 \"${WFCATALOG_ADDRESS}\"|g" /app/availability/js/interface.js && \
+  sed -i -E "s|(var WFCATALOG_ADDRESS =).*|\1 \"${WFCATALOG_ADDRESS}\"|g" /app/metrics/js/interface.js && \
+  sed -i -E "s|(var FDSNWS_ADDRESS =).*|\1 \"${FDSNWS_ADDRESS}\"|g" /app/availability/js/interface.js && \
+  sed -i -E "s|(var FDSNWS_ADDRESS =).*|\1 \"${FDSNWS_ADDRESS}\"|g" /app/metrics/js/interface.js && \
+  npm start;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
 # eida-docker-wf-guis
-sudo docker build -t wf:latest .
-sudo docker run -p 3000:3000 --name wf wf:latest
 
+Web interface for browsing seismic data availability and
+quality metrics provided by a WFCatalog service.
+
+### Build and run container
+
+The following commands will build and run a web interface container running on
+port 3000.
+It may be necessary to use `sudo` to run Docker commands.
+
+```bash
+docker build -t wf:latest .
+```
+
+```bash
+docker run -p 3000:3000 --name wf \
+  wf:latest
+```
+
+### Alternative data service urls
+
+URLs for WF Catalog and FDSNWS services can be overridden during container
+startup by setting environment variables.  The default values correspond to the
+_resif.fr_ service.
+
+```bash
+docker build -t wf:latest .
+docker run -p 3000:3000 --name wf \
+  -e "WFCATALOG_ADDRESS=http://ws.resif.fr/eidaws/wfcatalog/1/query" \
+  -e "FDSNWS_ADDRESS=http://ws.resif.fr/fdsnws/station/1/query" \
+  wf:latest
+```

--- a/code/availability/js/interface.js
+++ b/code/availability/js/interface.js
@@ -5,6 +5,7 @@ $('#menu_data .available').addClass('active')
 // Globals
 var cache, channelCodes;
 var WFCATALOG_ADDRESS = "http://ws.resif.fr/eidaws/wfcatalog/1/query";
+var FDSNWS_ADDRESS = "http://ws.resif.fr/fdsnws/station/1/query";
 var ENABLE_SUGGESTIONS = true;
 
 $("#network").val(getParameterByName("net"))
@@ -21,7 +22,7 @@ $(function () {
       "source": function (query, process) {
           return $.ajax({
               type: 'GET',// chargement du fichier externe monfichier-ajax.php 
-              url      : "http://ws.resif.fr/fdsnws/station/1/query?level=network",
+              url      : FDSNWS_ADDRESS + "?level=network",
               // Passage des données au fichier externe (ici le nom cliqué)  
               error    : function(request, error) { // Info Debuggage si erreur         
                         alert("Erreur : responseText: "+request.responseText);//+request.responseText);
@@ -56,7 +57,7 @@ $(function () {
           return $.ajax({
           type: 'GET',
           // chargement du fichier externe monfichier-ajax.php 
-          url      : "http://ws.resif.fr/fdsnws/station/1/query?level=station&network="+valeur,
+          url      : FDSNWS_ADDRESS + "?level=station&network=" + valeur,
           // Passage des données au fichier externe (ici le nom cliqué)  
           error    : function(request, error) { // Info Debuggage si erreur         
                       alert("Erreur : responseText: "+request.responseText);//+request.responseText);

--- a/code/metrics/js/interface.js
+++ b/code/metrics/js/interface.js
@@ -2,6 +2,7 @@
 // Globals
 var cache, channelCodes;
 var WFCATALOG_ADDRESS = "http://ws.resif.fr/eidaws/wfcatalog/1/query";
+var FDSNWS_ADDRESS = "http://ws.resif.fr/fdsnws/station/1/query";
 var ENABLE_SUGGESTIONS = true;
 var NODE = "RESIF Data Center";
 
@@ -15,7 +16,7 @@ $(function () {
       "source": function (query, process) {
           return $.ajax({
               type: 'GET',// chargement du fichier externe monfichier-ajax.php 
-              url      : "http://ws.resif.fr/fdsnws/station/1/query?level=network",
+              url      : FDSNWS_ADDRESS + "?level=network",
               // Passage des données au fichier externe (ici le nom cliqué)  
               error    : function(request, error) { // Info Debuggage si erreur         
                         alert("Erreur : responseText: "+request.responseText);//+request.responseText);
@@ -50,7 +51,7 @@ $(function () {
           return $.ajax({
           type: 'GET',
           // chargement du fichier externe monfichier-ajax.php 
-          url      : "http://ws.resif.fr/fdsnws/station/1/query?level=station&network="+valeur,
+          url      : FDSNWS_ADDRESS + "?level=station&network=" + valeur,
           // Passage des données au fichier externe (ici le nom cliqué)  
           error    : function(request, error) { // Info Debuggage si erreur         
                       alert("Erreur : responseText: "+request.responseText);//+request.responseText);


### PR DESCRIPTION
### Description

This merge request adds the ability to change the URLs for the WFCatalog and FDSNWS services at container start time.  This allows the same container to be used by different institutions without having to modify the container or website code.

### To test

Build and run the container following instructions in README.md.
Change the target URLs via the environment variables.
The updated values can be checked in the running container by running the following command on the host server:

```bash
curl http://localhost:3000/availability/js/interface.js | head
```